### PR TITLE
h1 Schriftgröße semantisches Wissensmanagement

### DIFF
--- a/smw/skript/html/site/stylesheets/extra.css
+++ b/smw/skript/html/site/stylesheets/extra.css
@@ -185,9 +185,11 @@ div.md-content a:hover:not(.md-footer-nav__link) {
     font-feature-settings: 'liga';
   }
 
+@media (max-width: 768px) {
   #semantisches-wissensmanagement-im-unternehmen-konzepte-technologien-anwendung {
     font-size: 1.5rem;
   }
+}
 
 /* }  */
 /* end SCREEN ONLY */ 

--- a/smw/skript/html/site/stylesheets/extra.css
+++ b/smw/skript/html/site/stylesheets/extra.css
@@ -185,7 +185,9 @@ div.md-content a:hover:not(.md-footer-nav__link) {
     font-feature-settings: 'liga';
   }
 
-
+  #semantisches-wissensmanagement-im-unternehmen-konzepte-technologien-anwendung {
+    font-size: 1.5rem;
+  }
 
 /* }  */
 /* end SCREEN ONLY */ 


### PR DESCRIPTION
Ich habe einen CSS-Eintrag hinzugefügt, um die Schriftgröße des h1 Elements mit der ID 'semantisches-wissensmanagement-im-unternehmen-konzepte-technologien-anwendung' auf Mobilgeräten zu limitieren. 
Für Desktopgeräte und Tablets bleibt die Schriftgröße unverändert. 

Vorher: (Galaxy S10+)
![image](https://github.com/StefanZander/lecture_notes/assets/32467054/9e84a2e5-dda8-4927-ab46-38b8a1cb7644)

Nachher:
![image](https://github.com/StefanZander/lecture_notes/assets/32467054/9c4e4365-9db9-4e81-b31d-f082fe61a5d4)

