### PR TITLE
fix: milestone 3 title typo

### DIFF
--- a/hci/vorlesung/mkdocs/docs/ms3.md
+++ b/hci/vorlesung/mkdocs/docs/ms3.md
@@ -1,4 +1,4 @@
-# Meilenstein 2: UI-Entwurf
+# Meilenstein 3: UI-Entwurf
 
 !!! success "Lernziele"
     - [x] Sie können eine Benutzungsschnittstelle mit geeigneten Diagrammen beschreiben


### PR DESCRIPTION
Guten Tag Herr Zander,

mir ist in der Vorbereitung für die Abgabe von MS3 der hier behobene Typo im Titel aufgefallen - nicht weiter schlimm aber einfach eine Konsistenzsache.

Viele Grüße,
Christian B.